### PR TITLE
RSE-247: Correct class name

### DIFF
--- a/CRM/EventsExtras/Hook/Pre/ManageEvent.php
+++ b/CRM/EventsExtras/Hook/Pre/ManageEvent.php
@@ -3,9 +3,9 @@
 use CRM_EventsExtras_SettingsManager as SettingsManager;
 
 /**
- * Class for Event Fee Pre Hook
+ * Class for for Pre Manage Event Hook
  */
-class CRM_EventsExtras_Hook_Pre_Event {
+class CRM_EventsExtras_Hook_Pre_ManageEvent {
 
   /**
    * Handle Hook Pre Event


### PR DESCRIPTION
## Overview
This PR is to fix error when creating new Event

## Before

When creating a new event the site shows Unexpected error as the class name was declared incorrectly.

## After

Event can be created without error.

## Technical Detail.

```
function eventsextras_civicrm_pre($op, $objectName, $id, &$params){
  $listeners = [
    new CRM_EventsExtras_Hook_Pre_ManageEvent(),
  ];
  foreach ($listeners as $currentListener) {
    $currentListener->handle($op, $objectName, $id, $params);
  }
}
```
The CRM_EventsExtras_Hook_Pre_ManageEvent was initiated and the  class was not found as the CRM_EventsExtras_Hook_Pre_ManageEvent class was declared incorrectly.

