### PR TITLE
RSE-245: Moved Events Extras Settings Menu

### DIFF
--- a/eventsextras.php
+++ b/eventsextras.php
@@ -151,7 +151,7 @@ function eventsextras_civicrm_preProcess($formName, &$form) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
  */
 function eventsextras_civicrm_navigationMenu(&$menu) {
-  _eventsextras_civix_insert_navigation_menu($menu, 'Administer/', array(
+  _eventsextras_civix_insert_navigation_menu($menu, 'Administer/CiviEvent', array(
     'label' => E::ts('Events Extras Settings'),
     'name' => 'events_extras_settings',
     'url' => 'civicrm/admin/setting/preferences/eventsextras',
@@ -160,4 +160,4 @@ function eventsextras_civicrm_navigationMenu(&$menu) {
     'separator' => 0,
   ));
   _eventsextras_civix_navigationMenu($menu);
-} 
+}


### PR DESCRIPTION

## Overview
This PR is to moved Events Extra Menu from under Administrator to Administrator/CiviEvent

## Before

Menu located under Administrator 
![Screenshot 2019-09-09 at 10 47 56](https://user-images.githubusercontent.com/208713/64521806-8fea6d00-d2f0-11e9-8131-02099da760f6.png)

## After
Menu located under Administrator/CiviEvent 
![Screenshot 2019-09-09 at 10 48 57](https://user-images.githubusercontent.com/208713/64521784-86f99b80-d2f0-11e9-8431-206d50a47bea.png)