### PR TITLE
Revert "RSE-245: Moved Events Extras Settings Menu"

### DIFF
--- a/eventsextras.php
+++ b/eventsextras.php
@@ -151,7 +151,7 @@ function eventsextras_civicrm_preProcess($formName, &$form) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
  */
 function eventsextras_civicrm_navigationMenu(&$menu) {
-  _eventsextras_civix_insert_navigation_menu($menu, 'Administer/CiviEvent', array(
+  _eventsextras_civix_insert_navigation_menu($menu, 'Administer/', array(
     'label' => E::ts('Events Extras Settings'),
     'name' => 'events_extras_settings',
     'url' => 'civicrm/admin/setting/preferences/eventsextras',
@@ -160,4 +160,4 @@ function eventsextras_civicrm_navigationMenu(&$menu) {
     'separator' => 0,
   ));
   _eventsextras_civix_navigationMenu($menu);
-}
+} 


### PR DESCRIPTION
Reverts compucorp/uk.co.compucorp.eventsextras#11 as PR was incorrectly merge to master.