### PR TITLE
RSE-142: Fixed typo in info.xml

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -5,8 +5,8 @@
   <description>This extensions allows CiviCRM admin to config generic Event pages</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>Compucropt Ltd.</author>
-    <email>hello@compucorp.co.ukk</email>
+    <author>Compucorp Ltd.</author>
+    <email>hello@compucorp.co.uk</email>
   </maintainer>
   <urls>
     <url desc="Main Extension Page">https://github.com/compucorp/uk.co.compucorp.eventsextras</url>


### PR DESCRIPTION
## Overview
This PR is to fix typo in info.xml

## Before
Author: Compucropt Ltd. (hello@compucorp.co.ukk)


## After
Author: Compucorp Ltd. (hello@compucorp.co.uk)
