### PR TITLE
MAE-326: Fix a bug and add unit tests

### DIFF
--- a/CRM/EventsExtras/Hook/Pre/ManageEvent.php
+++ b/CRM/EventsExtras/Hook/Pre/ManageEvent.php
@@ -82,7 +82,7 @@ class CRM_EventsExtras_Hook_Pre_ManageEvent {
       }
     }
     foreach ($fieldToProcess as $field => $value) {
-      if ($section != SettingsManager::EVENT_FEE && $field != 'payment_processor') {
+      if ($field != 'payment_processor') {
         $params[$field] = $value;
       }
     }

--- a/CRM/EventsExtras/Test/Fabricator/Setting.php
+++ b/CRM/EventsExtras/Test/Fabricator/Setting.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Class CRM_MventsExtras_Test_Fabricator_Setting
+ */
+class CRM_EventsExtras_Test_Fabricator_Setting {
+
+  /**
+   * @param array $params
+   */
+  public static function fabricate($params = []) {
+    foreach ($params as $key => $value) {
+      \Civi::settings()->set($key, $value);
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventFeeTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventFeeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+
+use CRM_EventsExtras_Test_Fabricator_Setting as SettingFabricator;
+use CRM_EventsExtras_SettingsManager as SettingsManager;
+
+require_once __DIR__ . '/../../../../BaseHeadlessTest.php';
+
+/**
+ * Class CRM_EventsExtras_Hook_BuildForm_EventFeeTest
+ *
+ * @group headless
+ */
+class CRM_EventsExtras_Hook_BuildForm_EventFeeTest extends BaseHeadlessTest {
+
+  /**
+   * @var CRM_Event_Form_ManageEvent_EventFee
+   */
+  private $eventFeeForm;
+
+  public function setUp() {
+    $formController = new CRM_Core_Controller();
+    $this->eventFeeForm = new CRM_Event_Form_ManageEvent_Fee();
+    $this->eventFeeForm->controller = $formController;
+    $this->eventFeeForm->buildForm();
+  }
+
+  public function testSetDefault() {
+    $this->assertNull($this->eventFeeForm->getElementValue('payment_processor')[0]);
+
+    SettingFabricator::fabricate([
+      SettingsManager::SETTING_FIELDS['PAYMENT_PROCESSOR_SELECTION'] => 0,
+      SettingsManager::SETTING_FIELDS['PAYMENT_PROCESSOR_SELECTION_DEFAULT'] => [3, 5],
+    ]);
+
+    $eventFeeFormHook = new CRM_EventsExtras_Hook_BuildForm_EventFee();
+    $eventFeeFormHook->handle('CRM_Event_Form_ManageEvent_Fee', $this->eventFeeForm);
+
+    $this->assertEquals(
+      [3, 5],
+      array_keys($this->eventFeeForm->_defaultValues['payment_processor'])
+    );
+  }
+
+}

--- a/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventInfoTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventInfoTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use CRM_EventsExtras_Test_Fabricator_Setting as SettingFabricator;
+use CRM_EventsExtras_SettingsManager as SettingsManager;
+
+require_once __DIR__ . '/../../../../BaseHeadlessTest.php';
+
+/**
+ * Class CRM_EventsExtras_Hook_BuildForm_EventInfoTest
+ *
+ * @group headless
+ */
+class CRM_EventsExtras_Hook_BuildForm_EventInfoTest extends BaseHeadlessTest {
+
+  /**
+   * @var CRM_EventsExtras_Hook_BuildForm_EventInfo
+   */
+  private $eventInfoForm;
+
+  public function setUp() {
+    $formController = new CRM_Core_Controller();
+    $this->eventInfoForm = new CRM_Event_Form_ManageEvent_EventInfo();
+    $this->eventInfoForm->controller = $formController;
+  }
+
+  public function testSetDefault() {
+    $formController = new CRM_Core_Controller();
+    $eventInfoForm = new CRM_Event_Form_ManageEvent_EventInfo();
+    $eventInfoForm->controller = $formController;
+    $eventInfoForm->buildForm();
+
+    $this->assertNull($eventInfoForm->getElementValue('default_role_id')[0]);
+
+    SettingFabricator::fabricate([
+      SettingsManager::SETTING_FIELDS['ROLES'] => 0,
+      SettingsManager::SETTING_FIELDS['ROLES_DEFAULT'] => 3,
+    ]);
+
+    $eventInfoFormHook = new CRM_EventsExtras_Hook_BuildForm_EventInfo();
+    $eventInfoFormHook->handle('CRM_Event_Form_ManageEvent_EventInfo', $eventInfoForm);
+
+    $this->assertEquals(3, $eventInfoForm->getElementValue('default_role_id')[0]);
+  }
+
+}

--- a/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventInfoTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventInfoTest.php
@@ -17,12 +17,6 @@ class CRM_EventsExtras_Hook_BuildForm_EventInfoTest extends BaseHeadlessTest {
    */
   private $eventInfoForm;
 
-  public function setUp() {
-    $formController = new CRM_Core_Controller();
-    $this->eventInfoForm = new CRM_Event_Form_ManageEvent_EventInfo();
-    $this->eventInfoForm->controller = $formController;
-  }
-
   public function testSetDefault() {
     $formController = new CRM_Core_Controller();
     $eventInfoForm = new CRM_Event_Form_ManageEvent_EventInfo();

--- a/tests/phpunit/CRM/EventsExtras/Hook/Pre/ManageEventTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/Pre/ManageEventTest.php
@@ -12,7 +12,6 @@ require_once __DIR__ . '/../../../../BaseHeadlessTest.php';
  */
 class CRM_EventsExtras_Hook_Pre_ManageEventTest extends BaseHeadlessTest {
 
-
   public function testEventInfo() {
 
     //fake params
@@ -39,7 +38,7 @@ class CRM_EventsExtras_Hook_Pre_ManageEventTest extends BaseHeadlessTest {
     ]);
 
     //make sure participant listing default is set
-    $participantListingDefault = SettingsManager::getSettingValue( SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING_DEFAULT']);
+    $participantListingDefault = SettingsManager::getSettingValue(SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING_DEFAULT']);
     $this->assertEquals(1, $participantListingDefault[SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING_DEFAULT']]);
 
     $preManageEventHook = new CRM_EventsExtras_Hook_Pre_ManageEvent();
@@ -92,7 +91,7 @@ class CRM_EventsExtras_Hook_Pre_ManageEventTest extends BaseHeadlessTest {
   public function testEventOnlineRegistration() {
 
     $params = [
-      'is_online_registration'=> 1,
+      'is_online_registration' => 1,
       'expiration_time' => NULL,
       'allow_selfcancelxfer' => NULL,
       'selfcancelxfer_time' => NULL,
@@ -121,4 +120,5 @@ class CRM_EventsExtras_Hook_Pre_ManageEventTest extends BaseHeadlessTest {
     $this->assertEquals(9, $params['max_additional_participants']);
 
   }
+
 }

--- a/tests/phpunit/CRM/EventsExtras/Hook/Pre/ManageEventTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/Pre/ManageEventTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use CRM_EventsExtras_Test_Fabricator_Setting as SettingFabricator;
+use CRM_EventsExtras_SettingsManager as SettingsManager;
+
+require_once __DIR__ . '/../../../../BaseHeadlessTest.php';
+
+/**
+ * Class CRM_EventsExtras_Hook_Pre_ManageEventTest
+ *
+ * @group headless
+ */
+class CRM_EventsExtras_Hook_Pre_ManageEventTest extends BaseHeadlessTest {
+
+
+  public function testEventInfo() {
+
+    //fake params
+    $params = [
+      'event_type_id' => 2,
+      'is_public' => NULL,
+      'is_map' => NULL,
+      'participant_listing_id' => NULL,
+    ];
+
+    //Fabricate settings if user select field to hide and set default value
+    SettingFabricator::fabricate([
+      SettingsManager::SETTING_FIELDS['INCLUDE_MAP_LOCATION_EVENT'] => 0,
+      SettingsManager::SETTING_FIELDS['INCLUDE_MAP_LOCATION_EVENT_DEFAULT'] => 1,
+      SettingsManager::SETTING_FIELDS['INCLUDE_MAP_PUBLIC_EVENT'] => 0,
+      SettingsManager::SETTING_FIELDS['INCLUDE_MAP_PUBLIC_EVENT_DEFAULT'] => 1,
+    ]);
+
+    //Fabricate settings if user to show field and default value was set.
+    //In this case default should not be assigned to to the param;
+    SettingFabricator::fabricate([
+      SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING'] => 1,
+      SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING_DEFAULT'] => 1,
+    ]);
+
+    //make sure participant listing default is set
+    $participantListingDefault = SettingsManager::getSettingValue( SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING_DEFAULT']);
+    $this->assertEquals(1, $participantListingDefault[SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING_DEFAULT']]);
+
+    $preManageEventHook = new CRM_EventsExtras_Hook_Pre_ManageEvent();
+    $preManageEventHook->handle('create', 'Event', NULL, $params);
+
+    $this->assertEquals(1, $params['is_public']);
+    $this->assertEquals(1, $params['is_map']);
+
+    $this->assertNull(NULL);
+
+  }
+
+  public function testEventFee() {
+
+    $params = [
+      'is_monetary' => 1,
+      'payment_processor' => NULL,
+      'currency' => NULL,
+      'is_pay_later' => NULL,
+      'pay_later_text' => NULL,
+      'pay_later_receipt' => NULL,
+      'is_billing_required' => NULL,
+    ];
+
+    SettingFabricator::fabricate([
+      SettingsManager::SETTING_FIELDS['CURRENCY'] => 0,
+      SettingsManager::SETTING_FIELDS['CURRENCY_DEFAULT'] => 1,
+      SettingsManager::SETTING_FIELDS['PAYMENT_PROCESSOR_SELECTION'] => 0,
+      SettingsManager::SETTING_FIELDS['PAYMENT_PROCESSOR_SELECTION_DEFAULT'] => [7, 8],
+      SettingsManager::SETTING_FIELDS['PAY_LATER_OPTION'] => 0,
+      SettingsManager::SETTING_FIELDS['PAY_LATER_OPTION_DEFAULT'] => 1,
+      SettingsManager::SETTING_FIELDS['PAY_LATER_OPTION_DEFAULT_LABEL'] => 'Test Label',
+      SettingsManager::SETTING_FIELDS['PAY_LATER_OPTION_DEFAULT_LABEL_INSTRUCTION'] => 'Test Instruction',
+      SettingsManager::SETTING_FIELDS['PAY_LATER_OPTION_DEFAULT_BILLING_ADDRESS'] => 1,
+    ]);
+
+    $preManageEventHook = new CRM_EventsExtras_Hook_Pre_ManageEvent();
+    $preManageEventHook->handle('edit', 'Event', '1', $params);
+
+    $this->assertEquals(1, $params['currency']);
+    //payment processor should remain NULl as we are not set payment process on Pre Hook'
+    $this->assertNull($params['payment_processor']);
+    $this->assertEquals(1, $params['is_pay_later']);
+    $this->assertEquals('Test Label', $params['pay_later_text']);
+    $this->assertEquals('Test Instruction', $params['pay_later_receipt']);
+    $this->assertEquals(1, $params['is_billing_required']);
+
+  }
+
+  public function testEventOnlineRegistration() {
+
+    $params = [
+      'is_online_registration'=> 1,
+      'expiration_time' => NULL,
+      'allow_selfcancelxfer' => NULL,
+      'selfcancelxfer_time' => NULL,
+      'is_multiple_registrations' => NULL,
+      'max_additional_participants' => NULL,
+    ];
+
+    SettingFabricator::fabricate([
+      SettingsManager::SETTING_FIELDS['PENDING_PARTICIPANT_EXPIRATION'] => 0,
+      SettingsManager::SETTING_FIELDS['PENDING_PARTICIPANT_EXPIRATION_DEFAULT'] => 24,
+      SettingsManager::SETTING_FIELDS['ALLOW_SELF_SERVICE'] => 0,
+      SettingsManager::SETTING_FIELDS['ALLOW_SELF_SERVICE_DEFAULT'] => 1,
+      SettingsManager::SETTING_FIELDS['ALLOW_SELF_SERVICE_DEFAULT_TIME_LIMIT'] => 48,
+      SettingsManager::SETTING_FIELDS['REGISTER_MULTIPLE_PARTICIPANTS'] => 0,
+      SettingsManager::SETTING_FIELDS['REGISTER_MULTIPLE_PARTICIPANTS_DEFAULT'] => 1,
+      SettingsManager::SETTING_FIELDS['REGISTER_MULTIPLE_PARTICIPANTS_DEFAULT_MAXIMUM_PARTICIPANT'] => 9,
+    ]);
+
+    $preManageEventHook = new CRM_EventsExtras_Hook_Pre_ManageEvent();
+    $preManageEventHook->handle('edit', 'Event', '1', $params);
+
+    $this->assertEquals(24, $params['expiration_time']);
+    $this->assertEquals(1, $params['allow_selfcancelxfer']);
+    $this->assertEquals(48, $params['selfcancelxfer_time']);
+    $this->assertEquals(1, $params['is_multiple_registrations']);
+    $this->assertEquals(9, $params['max_additional_participants']);
+
+  }
+}

--- a/tests/phpunit/CRM/EventsExtras/Hook/Pre/ManageEventTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/Pre/ManageEventTest.php
@@ -30,8 +30,8 @@ class CRM_EventsExtras_Hook_Pre_ManageEventTest extends BaseHeadlessTest {
       SettingsManager::SETTING_FIELDS['INCLUDE_MAP_PUBLIC_EVENT_DEFAULT'] => 1,
     ]);
 
-    //Fabricate settings if user to show field and default value was set.
-    //In this case default should not be assigned to to the param;
+    //Fabricate settings if user select to show field and default value was set.
+    //In this case default should not be assigned to the param;
     SettingFabricator::fabricate([
       SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING'] => 1,
       SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING_DEFAULT'] => 1,
@@ -47,7 +47,7 @@ class CRM_EventsExtras_Hook_Pre_ManageEventTest extends BaseHeadlessTest {
     $this->assertEquals(1, $params['is_public']);
     $this->assertEquals(1, $params['is_map']);
 
-    $this->assertNull(NULL);
+    $this->assertNull($params['participant_listing_id']);
 
   }
 


### PR DESCRIPTION
## Overview
This PR is to fix a bug on the Pre hook when the value have not been set  on the Event Fee form as well as add unit tests for BuildForm and Pre Hooks

## Before

- Values have not been set on Event Fee form Pre hook
- BuildForm and Pre hooks tests did not exist. 

## After

- Values are now preset property on Pre hook on Event Fee form. 
- Event Info, Event Fee BuildForm hooks are added to the extension
- ManageEvent Pre hook is added to the extension. 
