### PR TITLE
MAE-404: Move Event Extras Settings menu to under Administer/CiviEvent

### DIFF
--- a/eventsextras.php
+++ b/eventsextras.php
@@ -171,7 +171,7 @@ function eventsextras_civicrm_entityTypes(&$entityTypes) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
  */
 function eventsextras_civicrm_navigationMenu(&$menu) {
-  _eventsextras_civix_insert_navigation_menu($menu, 'Administer/', array(
+  _eventsextras_civix_insert_navigation_menu($menu, 'Administer/CiviEvent', array(
     'label' => E::ts('Events Extras Settings'),
     'name' => 'events_extras_settings',
     'url' => 'civicrm/admin/setting/preferences/eventsextras',
@@ -180,4 +180,4 @@ function eventsextras_civicrm_navigationMenu(&$menu) {
     'separator' => 0,
   ));
   _eventsextras_civix_navigationMenu($menu);
-} 
+}


### PR DESCRIPTION
## Overview

This PR is to move  Event Extras Settings menu from Administer to under Administer -> CiviEvent 

## Before

![Screenshot from 2020-11-16 10-46-06](https://user-images.githubusercontent.com/208713/99244934-b3654d80-27fa-11eb-8a10-1157544ddb1d.png)

## After

![Screenshot from 2020-11-16 11-01-31](https://user-images.githubusercontent.com/208713/99245521-9c732b00-27fb-11eb-9d73-54c3ecd04831.png)
