### PR TITLE
MAE-399: Fix a typo in info.xml

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -5,7 +5,7 @@
   <description>This extensions allows CiviCRM admin to config generic Event pages</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>Compucropt Ltd.</author>
+    <author>Compucorp Ltd.</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>c
   <releaseDate>2020-07-16</releaseDate>


### PR DESCRIPTION
## Overview
This PR is to fix typo in info.xml

## Before
Author: Compucropt Ltd. (info@compucorp.co.uk)
![Screenshot from 2020-12-11 12-23-05](https://user-images.githubusercontent.com/74309109/101895369-1eaeff00-3bb0-11eb-9360-4799a6db4c0a.png)


## After
Author: Compucorp Ltd. (info@compucorp.co.uk)
![Screenshot from 2020-12-11 12-26-14](https://user-images.githubusercontent.com/74309109/101895395-28386700-3bb0-11eb-9377-e9ffd5401b2d.png)
