### PR TITLE
MAE-422: Create upgrader to reset the menu cache

### DIFF
--- a/CRM/EventsExtras/Upgrader.php
+++ b/CRM/EventsExtras/Upgrader.php
@@ -12,4 +12,18 @@ class CRM_EventsExtras_Upgrader extends CRM_EventsExtras_Upgrader_Base {
     $this->executeSqlFile('sql/auto_uninstall.sql');
   }
 
+  public function upgrade_0001() {
+    $this->resetMenuCache();
+
+    return TRUE;
+  }
+
+  /**
+   * After modifying the navigation menu we should reset the menu cache
+   */
+  private function resetMenuCache() {
+    $params = [];
+    civicrm_api3('System', 'flush', $params);
+  }
+
 }


### PR DESCRIPTION
## Overview
After adding or modifying the navigation menu, we must reset CiviCRM "menu cache".

## Before
Changing the menu item well not take effect for current CiviCRM sites.

## After
The user will be asked to execute the upgrades in 'CiviCRM System Status'
![Screenshot from 2020-12-28 12-11-27](https://user-images.githubusercontent.com/74309109/103207656-9480cd80-4907-11eb-8a6f-bf39a55f6466.png)

or in 'CiviCRM Extensions'
![Screenshot from 2020-12-28 12-35-23](https://user-images.githubusercontent.com/74309109/103208384-3a810780-4909-11eb-820d-56c5dfaa38ff.png)

## Comments
We can do this this in a web browser by redirecting the user to `/civicrm/menu/rebuild?reset=1` or using Drush by running `drush cc civicrm` but using the upgrader is the easiest/direct way.

