### PR TITLE
MAE-541:Make event summary and description form fields visibility respond to configured corresponding settings

### DIFF
--- a/CRM/EventsExtras/Hook/BuildForm/EventInfo.php
+++ b/CRM/EventsExtras/Hook/BuildForm/EventInfo.php
@@ -77,6 +77,18 @@ class CRM_EventsExtras_Hook_BuildForm_EventInfo extends CRM_EventsExtras_Hook_Bu
       $fieldIdsToHide[] = 'is_public';
     }
 
+    $showEventDescription = SettingsManager::SETTING_FIELDS['EVENT_DESCRIPTION'];
+    $settingValues = SettingsManager::getSettingsValue($showEventDescription);
+    if ($settingValues[$showEventDescription] == 0) {
+      $fieldIdsToHide[] = 'description';
+    }
+
+    $showEventSummary = SettingsManager::SETTING_FIELDS['PARTICIPANT_SUMMARY'];
+    $settingValues = SettingsManager::getSettingsValue($showEventSummary);
+    if ($settingValues[$showEventSummary] == 0) {
+      $fieldIdsToHide[] = 'summary';
+    }
+
     $this->hideFields($fieldIdsToHide);
     $form->setDefaults($defaults);
   }


### PR DESCRIPTION
## Before

1. Login to a Test site with Civi 5.35 version and latest compuclient extensions
2. Navigate to CiviEvent Extras Settings -  /civicrm/admin/setting/preferences/eventsextras
3. Hide "Events Summary" and "Complete Description" settings and submit the changes 

![image](https://user-images.githubusercontent.com/85277674/128684272-a6159098-0718-4731-bffe-07175c618eba.png)

4. Navigate to /civicrm/event/add?action=add
_We can see that the fields do not respond to the configured settings_
![image](https://user-images.githubusercontent.com/85277674/128684301-eb340984-0ab8-49c7-b280-3b0ec991ac53.png)


## After
1. Login to a Test site with Civi 5.35 version and latest compuclient extensions
2. Navigate to CiviEvent Extras Settings -  /civicrm/admin/setting/preferences/eventsextras
3. Hide "Events Summary" and "Complete Description" settings and submit the changes 

4. Navigate to /civicrm/event/add?action=add
_We can see that the fields now respond to the configured settings_
![image](https://user-images.githubusercontent.com/85277674/128684678-4e8985ae-72d1-47a7-8b8f-e1df5d2bed55.png)





