### PR TITLE
MAE-891: Use PHP8.0 in test container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.0.0
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.28.3
+          version: 5.51.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventFeeTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventFeeTest.php
@@ -18,7 +18,7 @@ class CRM_EventsExtras_Hook_BuildForm_EventFeeTest extends BaseHeadlessTest {
    */
   private $eventFeeForm;
 
-  public function setUp() {
+  public function setUp(): void {
     $formController = new CRM_Core_Controller();
     $this->eventFeeForm = new CRM_Event_Form_ManageEvent_Fee();
     $this->eventFeeForm->controller = $formController;
@@ -26,7 +26,7 @@ class CRM_EventsExtras_Hook_BuildForm_EventFeeTest extends BaseHeadlessTest {
   }
 
   public function testSetDefault() {
-    $this->assertNull($this->eventFeeForm->getElementValue('payment_processor')[0]);
+    $this->assertEmpty($this->eventFeeForm->getElementValue('payment_processor'));
 
     SettingFabricator::fabricate([
       SettingsManager::SETTING_FIELDS['PAYMENT_PROCESSOR_SELECTION'] => 0,

--- a/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventInfoTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventInfoTest.php
@@ -23,7 +23,7 @@ class CRM_EventsExtras_Hook_BuildForm_EventInfoTest extends BaseHeadlessTest {
     $eventInfoForm->controller = $formController;
     $eventInfoForm->buildForm();
 
-    $this->assertNull($eventInfoForm->getElementValue('default_role_id')[0]);
+    $this->assertEmpty($eventInfoForm->getElementValue('default_role_id'));
 
     SettingFabricator::fabricate([
       SettingsManager::SETTING_FIELDS['ROLES'] => 0,


### PR DESCRIPTION
## Overview
Update the PHP container and CiviCRM version used in the test workflow, and also fixed errors that occurred after the update.