### PR TITLE
MAE-975: Fix settings page error

### DIFF
--- a/CRM/EventsExtras/Form/Settings.php
+++ b/CRM/EventsExtras/Form/Settings.php
@@ -249,7 +249,8 @@ class CRM_EventsExtras_Form_Settings extends CRM_Core_Form {
     }
 
     $defaults['eventsextras_payment_processor_selection_default'] =
-      array_fill_keys($defaults['eventsextras_payment_processor_selection_default'], '1');
+      is_array($defaults['eventsextras_payment_processor_selection_default']) ?
+      array_fill_keys($defaults['eventsextras_payment_processor_selection_default'], '1') : NULL;
 
     return $defaults;
   }


### PR DESCRIPTION
## Overview
This PR fixes the extension settings page returning an error.

## Before
The settings page returns an error.
![image](https://user-images.githubusercontent.com/85277674/205265146-0d8b8aab-0a8e-4ebb-b379-7ca6ea479c5c.png)


## After
The settings page is displayed.
<img width="1228" alt="Screenshot 2022-12-02 at 10 49 17" src="https://user-images.githubusercontent.com/85277674/205265081-01685a60-6add-4488-b2c8-b2dcc58332e5.png">


## Technical Details
The `eventextras` settings page was returning CiviCRM WSOD because it is mandatory in PHP8 for the first parameter in array_fill_key to be an array.

```
TypeError: array_fill_keys(): Argument #1 ($keys) must be of type array, string given in array_fill_keys() (line 252 of profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.eventsextras/CRM/EventsExtras/Form/Settings.php).
```

To resolve the error we simply ensure `$defaults['eventsextras_payment_processor_selection_default']` is an array before passing it to array_fill_keys.