### PR TITLE
BTHAMM-7: Fix Participant Role Assignment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
+    container: compucorp/civicrm-buildkit:1.3.1-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,7 +29,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.94 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:

--- a/CRM/EventsExtras/Hook/BuildForm/BaseEvent.php
+++ b/CRM/EventsExtras/Hook/BuildForm/BaseEvent.php
@@ -84,6 +84,7 @@ abstract class CRM_EventsExtras_Hook_BuildForm_BaseEvent {
     CRM_Core_Resources::singleton()->addScript(
       "CRM.$(function($) {
         $('{$selector}').hide();
+        $('{$selector} .required').removeClass('required');
       });
     ");
   }

--- a/CRM/EventsExtras/Hook/BuildForm/EventInfo.php
+++ b/CRM/EventsExtras/Hook/BuildForm/EventInfo.php
@@ -48,6 +48,7 @@ class CRM_EventsExtras_Hook_BuildForm_EventInfo extends CRM_EventsExtras_Hook_Bu
     if ($settingValues[$showRoles] == 0) {
       $defaults['default_role_id'] = $settingValues[$roleDefault];
       $fieldIdsToHide[] = 'default_role_id';
+      $form->getElement('default_role_id')->setSelected($settingValues[$roleDefault]);
     }
 
     $showParticipantListing = SettingsManager::SETTING_FIELDS['PARTICIPANT_LISTING'];
@@ -57,6 +58,7 @@ class CRM_EventsExtras_Hook_BuildForm_EventInfo extends CRM_EventsExtras_Hook_Bu
     if ($settingValues[$showParticipantListing] == 0) {
       $defaults['participant_listing_id'] = $settingValues[$participantListingDefault];
       $fieldIdsToHide[] = 'participant_listing_id';
+      $form->getElement('participant_listing_id')->setSelected($settingValues[$participantListingDefault]);
     }
 
     $showIncludeMap = SettingsManager::SETTING_FIELDS['INCLUDE_MAP_LOCATION_EVENT'];


### PR DESCRIPTION
## Overview
Previously even when the default role was hidden in civi event extras and set to a particular role, the user was not able to submit the event creation form due to the default role field being required secondly the selected role was not being assigned to new participants. This pr fixes both of these issues, now the user is able to submit the event creation form even when default role field is hidden and selected role is also getting assigned to new participants.

## Before
<img width="635" alt="Screenshot 2024-03-25 at 11 36 34 AM" src="https://github.com/compucorp/uk.co.compucorp.eventsextras/assets/147053234/2ff2f8bd-a480-4c69-909e-1ec277308285">
<img width="1575" alt="Screenshot 2024-03-25 at 11 32 43 AM" src="https://github.com/compucorp/uk.co.compucorp.eventsextras/assets/147053234/a4cf20ad-7fca-4131-bf72-4b77c0fc8a58">
<img width="1595" alt="Screenshot 2024-03-25 at 11 39 42 AM" src="https://github.com/compucorp/uk.co.compucorp.eventsextras/assets/147053234/cac31fea-204c-4b10-b6ba-e4bc81ab1964">


## After
<img width="1792" alt="Screenshot 2024-04-08 at 12 42 37 PM" src="https://github.com/compucorp/uk.co.compucorp.eventsextras/assets/147053234/a6c41eee-aaa0-4699-8454-c83471b4d558">


