### PR TITLE
CIWEM-407: Fix Confirmation Email For Event Registration

### DIFF
--- a/CRM/EventsExtras/Hook/AlterMailParams/EventRegistrationConfirmation.php
+++ b/CRM/EventsExtras/Hook/AlterMailParams/EventRegistrationConfirmation.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Alter mail params hook for event registration confirmation.
+ */
+class CRM_EventsExtras_Hook_AlterMailParams_EventRegistrationConfirmation {
+
+  public static function shouldHandle(array $params, $context): bool {
+    return !empty($params['tplParams']['event']) && !empty($params['tplParams']['custom_pre_id']) && !empty($params['tplParams']['contactID'])
+      && $context === 'messageTemplate' && isset($params['tplParams']['customPre'][0]) && count(array_filter($params['tplParams']['customPre'][0])) === 0;
+  }
+
+  public function handle(array &$params): void {
+    $fields = CRM_Core_BAO_UFGroup::getFields($params['tplParams']['custom_pre_id'], FALSE, CRM_Core_Action::VIEW,
+      NULL, NULL, FALSE, NULL,
+      FALSE, NULL, CRM_Core_Permission::CREATE,
+      'field_name', TRUE
+    );
+
+    $values = [];
+    CRM_Core_BAO_UFGroup::getValues($params['tplParams']['contactID'], $fields, $values, FALSE);
+
+    $params['tplParams']['customPre'][0] = $values;
+  }
+
+}

--- a/eventsextras.php
+++ b/eventsextras.php
@@ -181,3 +181,16 @@ function eventsextras_civicrm_navigationMenu(&$menu) {
   ));
   _eventsextras_civix_navigationMenu($menu);
 }
+
+/**
+ * Implements hook_civicrm_alterMailParams().
+ */
+function eventsextras_civicrm_alterMailParams(&$params, $context) {
+  $hooks = [CRM_EventsExtras_Hook_AlterMailParams_EventRegistrationConfirmation::class];
+
+  foreach ($hooks as $hook) {
+    if ($hook::shouldHandle($params, $context)) {
+      (new $hook())->handle($params, $context);
+    }
+  }
+}


### PR DESCRIPTION
## Overview
While registering multiple participants and paying through stripe the fist contact's information was missing from the confirmation email. This pr fixes this issue.

## Before
<img width="1792" alt="Screenshot 2024-06-20 at 6 43 23 PM" src="https://github.com/compucorp/uk.co.compucorp.eventsextras/assets/147053234/45daa427-361b-43b7-9c9b-ec3c1cc9deba">

## After
<img width="1792" alt="Screenshot 2024-06-20 at 6 42 15 PM" src="https://github.com/compucorp/uk.co.compucorp.eventsextras/assets/147053234/5c5408fc-c698-4d40-aa03-f0469b074e26">
