### PR TITLE
GGS-40: Remove Disabled Options From Setting Page

### DIFF
--- a/CRM/EventsExtras/Form/Settings.php
+++ b/CRM/EventsExtras/Form/Settings.php
@@ -208,6 +208,7 @@ class CRM_EventsExtras_Form_Settings extends CRM_Core_Form {
         'api.OptionValue.get' => [
           '
           option_group_id' => 'id',
+          'is_active' => 1,
           'options' => [
             'limit' => 0,
           ],


### PR DESCRIPTION
## Overview
This pr removes the disabled option from settings page for all the settings that refers to option groups.

## Before
All the available option values for a setting were displayed regardless of the fact that an option is enabled or disabled.

## After
Only enabled options appears in settings.

