### PR TITLE
ASESPRT-821: Handle Thank You Page Refresh

### DIFF
--- a/CRM/EventsExtras/Hook/BuildForm/EventRegistrationThankYou.php
+++ b/CRM/EventsExtras/Hook/BuildForm/EventRegistrationThankYou.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * BuildForm hook listener for the public Event Registration wizard.
+ */
+class CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou {
+
+  /**
+   * Hook entry point.
+   */
+  public function handle(string $formName, CRM_Core_Form &$form): void {
+    if ($formName !== CRM_Event_Form_Registration_Register::class) {
+      return;
+    }
+
+    $this->storeEventIdForFlow($form);
+  }
+
+  /**
+   * Extract the event id and qfKey from the form and hand them to the service for caching.
+   */
+  private function storeEventIdForFlow(CRM_Event_Form_Registration_Register &$form): void {
+    $eventId = $this->resolveEventId($form);
+    if (!$eventId) {
+      return;
+    }
+
+    $qfKey = $this->extractQfKey($form);
+    if (!$qfKey) {
+      return;
+    }
+
+    CRM_EventsExtras_Service_ThankYouPageRedirect::storeEventId($qfKey, $eventId);
+  }
+
+  /**
+   * Resolve the event id the form is attached to.
+   */
+  private function resolveEventId(CRM_Event_Form_Registration_Register $form): ?int {
+    try {
+      if (method_exists($form, 'getEventID')) {
+        $eventId = (int) $form->getEventID();
+        if ($eventId > 0) {
+          return $eventId;
+        }
+      }
+    }
+    catch (Throwable $e) {
+      // getEventID() may send its own "Missing Event ID" response in edge
+      // cases - swallow so this hook can never be the cause of a broken form.
+    }
+
+    if (!empty($form->_eventId) && is_numeric($form->_eventId)) {
+      return (int) $form->_eventId;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Prefer the controller's qfKey; fall back to the request parameters
+   */
+  private function extractQfKey(CRM_Event_Form_Registration_Register $form): ?string {
+    $key = NULL;
+    if (isset($form->controller) && is_object($form->controller) && !empty($form->controller->_key)) {
+      $key = $form->controller->_key;
+    }
+
+    if (!$key) {
+      $key = $_POST['qfKey'] ?? $_GET['qfKey'] ?? $_REQUEST['qfKey'] ?? NULL;
+    }
+
+    return (is_string($key) && $key !== '') ? $key : NULL;
+  }
+
+}

--- a/CRM/EventsExtras/Service/ThankYouPageRedirect.php
+++ b/CRM/EventsExtras/Service/ThankYouPageRedirect.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * Service that handles the "refresh the Event Registration Thank You page" edge case.
+ */
+class CRM_EventsExtras_Service_ThankYouPageRedirect {
+
+  /**
+   * CiviCRM cache bucket used to persist qfKey -> event id mappings.
+   */
+  const CACHE_BUCKET = 'session';
+
+  /**
+   * Prefix applied to every cache key so our data is easy to namespace.
+   */
+  const CACHE_KEY_PREFIX = 'eventsextras_register_qfkey_';
+
+  /**
+   * Fallback TTL (seconds) used when "secure_cache_timeout_minutes" is empty or 0.
+   */
+  const DEFAULT_TTL_SECONDS = 20 * 60;
+
+  /**
+   * CiviCRM route handled by this redirect.
+   */
+  const EVENT_REGISTER_PATH = 'civicrm/event/register';
+
+  /**
+   * Prefix of the CiviCRM session cache key under which event registration controller persists its state.
+   */
+  const WIZARD_SESSION_KEY_PREFIX = 'CiviCRM_CRM_Event_Controller_Registration_';
+
+  /**
+   * Persist the qfKey to event id mapping used to recover the event id if the Thank You page is refreshed.
+   */
+  public static function storeEventId(string $qfKey, int $eventId): void {
+    if (!is_string($qfKey) || $qfKey === '' || !$eventId) {
+      return;
+    }
+
+    Civi::cache(self::CACHE_BUCKET)->set(self::cacheKey($qfKey), $eventId, self::getTtlSeconds());
+  }
+
+  /**
+   * Symfony listener for "civi.invoke.auth".
+   */
+  public static function redirectIfNeeded(\Civi\Core\Event\GenericHookEvent $event) {
+    if (!self::isThankYouRefreshWithoutId($event)) {
+      return;
+    }
+
+    $qfKey = self::getRequestQfKey();
+    if (!$qfKey) {
+      return;
+    }
+
+    if (!self::isWizardSessionFlushed($qfKey)) {
+      return;
+    }
+
+    $eventId = self::cacheGet($qfKey);
+    if (!$eventId) {
+      return;
+    }
+
+    // Guard against redirecting to an event that has since been deleted,
+    // which would just bounce the user into a second error page.
+    $eventExists = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $eventId, 'id');
+    if (!$eventExists) {
+      self::cacheDelete($qfKey);
+      return;
+    }
+
+    // We deliberately do NOT delete the mapping here: repeat refreshes /
+    // back button presses within the TTL should all resolve to the same
+    // event rather than silently failing after the first redirect. The
+    // mapping expires naturally when the underlying session TTL lapses.
+
+    $url = CRM_Utils_System::url(self::EVENT_REGISTER_PATH, ['id' => $eventId, 'reset' => 1], TRUE, NULL, FALSE);
+    CRM_Utils_System::redirect($url);
+  }
+
+  /**
+   * Is the current request a Thank You page display that has lost its event id?
+   */
+  private static function isThankYouRefreshWithoutId(\Civi\Core\Event\GenericHookEvent $event): bool {
+    $args = (isset($event->args) && is_array($event->args)) ? $event->args : [];
+    if (implode('/', $args) !== self::EVENT_REGISTER_PATH) {
+      return FALSE;
+    }
+
+    if (empty($_REQUEST['_qf_ThankYou_display'])) {
+      return FALSE;
+    }
+
+    // If an id is already in the request we leave it alone - either CiviCRM
+    // can use it, or its own validation should surface a more precise error.
+    if (!empty($_REQUEST['id'])) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Whether CiviCRM's own wizard session cache no longer holds an event id for the given qfKey.
+   */
+  private static function isWizardSessionFlushed(string $qfKey): bool {
+    $sessionData = Civi::cache(self::CACHE_BUCKET)->get(self::WIZARD_SESSION_KEY_PREFIX . $qfKey);
+
+    if (!is_array($sessionData)) {
+      return TRUE;
+    }
+
+    return empty($sessionData['id']);
+  }
+
+  /**
+   * Read the qfKey from the current request.
+   */
+  private static function getRequestQfKey(): ?string {
+    $key = $_POST['qfKey'] ?? $_GET['qfKey'] ?? $_REQUEST['qfKey'] ?? NULL;
+    return (is_string($key) && $key !== '') ? $key : NULL;
+  }
+
+  /**
+   * Build a fully-prefixed cache key for a qfKey.
+   */
+  private static function cacheKey(string $qfKey): string {
+    return self::CACHE_KEY_PREFIX . $qfKey;
+  }
+
+  /**
+   * Look up a qfKey -> event id mapping.
+   */
+  private static function cacheGet(string $qfKey): ?int {
+    $value = Civi::cache(self::CACHE_BUCKET)->get(self::cacheKey($qfKey));
+
+    if (!is_numeric($value)) {
+      return NULL;
+    }
+    $eventId = (int) $value;
+
+    return $eventId > 0 ? $eventId : NULL;
+  }
+
+  /**
+   * Remove a qfKey -> event id mapping.
+   */
+  private static function cacheDelete(string $qfKey): void {
+    Civi::cache(self::CACHE_BUCKET)->delete(self::cacheKey($qfKey));
+  }
+
+  /**
+   * TTL (seconds) for stored event ids. Mirrors CiviCRM's own wizard session cache TTL.
+   */
+  private static function getTtlSeconds(): int {
+    $minutes = (int) Civi::settings()->get('secure_cache_timeout_minutes');
+    if (!$minutes || $minutes <= 0) {
+      return self::DEFAULT_TTL_SECONDS;
+    }
+
+    return $minutes * 60;
+  }
+
+}

--- a/eventsextras.php
+++ b/eventsextras.php
@@ -14,6 +14,7 @@ function eventsextras_civicrm_buildForm($formName, &$form) {
     new CRM_EventsExtras_Hook_BuildForm_EventInfo(),
     new CRM_EventsExtras_Hook_BuildForm_EventFee(),
     new CRM_EventsExtras_Hook_BuildForm_EventRegistration(),
+    new CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou(),
   ];
   foreach ($listeners as $currentListener) {
     $currentListener->handle($formName, $form);
@@ -41,6 +42,18 @@ function eventsextras_civicrm_pre($op, $objectName, $id, &$params) {
  */
 function eventsextras_civicrm_config(&$config) {
   _eventsextras_civix_civicrm_config($config);
+
+  // Guard against double-registration if hook_civicrm_config fires more than
+  // once in a request (e.g. after a cache rebuild).
+  if (isset(Civi::$statics[__FUNCTION__])) {
+    return;
+  }
+  Civi::$statics[__FUNCTION__] = 1;
+
+  Civi::dispatcher()->addListener(
+    'civi.invoke.auth',
+    ['CRM_EventsExtras_Service_ThankYouPageRedirect', 'redirectIfNeeded']
+  );
 }
 
 /**

--- a/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventRegistrationThankYouTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Hook/BuildForm/EventRegistrationThankYouTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use CRM_EventsExtras_Service_ThankYouPageRedirect as Service;
+use CRM_EventsExtras_Test_Fabricator_Event as EventFabricator;
+
+require_once __DIR__ . '/../../../../BaseHeadlessTest.php';
+
+/**
+ * @group headless
+ */
+class CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYouTest extends BaseHeadlessTest {
+
+  private const QFKEY = 'test_hook_qfkey_xyz';
+  private const REGISTER_FORM_NAME = 'CRM_Event_Form_Registration_Register';
+
+  public function setUp(): void {
+    $_GET = [];
+    $_POST = [];
+    $_REQUEST = [];
+    Civi::cache('session')->clear();
+  }
+
+  public function testHandleStoresMappingForRegisterForm(): void {
+    $event = EventFabricator::fabricate();
+    $eventId = (int) $event['id'];
+    $form = $this->fakeForm($eventId, self::QFKEY);
+
+    (new CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou())
+      ->handle(self::REGISTER_FORM_NAME, $form);
+
+    $this->assertSame($eventId, Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY));
+  }
+
+  public function testHandleIsNoOpForUnrelatedForm(): void {
+    $event = EventFabricator::fabricate();
+    $eventId = (int) $event['id'];
+    $form = $this->fakeForm($eventId, self::QFKEY);
+
+    (new CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou())
+      ->handle('CRM_Event_Form_Registration_Confirm', $form);
+
+    $this->assertNull(Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY));
+  }
+
+  public function testHandleFallsBackToEventIdPropertyWhenGetEventIDThrows(): void {
+    $event = EventFabricator::fabricate();
+    $eventId = (int) $event['id'];
+    $form = $this->fakeForm($eventId, self::QFKEY, TRUE);
+
+    (new CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou())
+      ->handle(self::REGISTER_FORM_NAME, $form);
+
+    $this->assertSame($eventId, Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY));
+  }
+
+  public function testHandleIsNoOpWhenEventIdCannotBeResolved(): void {
+    $form = $this->fakeForm(NULL, self::QFKEY);
+
+    (new CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou())
+      ->handle(self::REGISTER_FORM_NAME, $form);
+
+    $this->assertNull(Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY));
+  }
+
+  public function testHandleIsNoOpWhenQfKeyCannotBeResolved(): void {
+    $event = EventFabricator::fabricate();
+    $eventId = (int) $event['id'];
+    $form = $this->fakeForm($eventId, NULL);
+
+    (new CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou())
+      ->handle(self::REGISTER_FORM_NAME, $form);
+
+    $this->assertNull(Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY));
+  }
+
+  public function testHandleFallsBackToRequestQfKey(): void {
+    $event = EventFabricator::fabricate();
+    $eventId = (int) $event['id'];
+    $_REQUEST['qfKey'] = self::QFKEY;
+    $form = $this->fakeForm($eventId, NULL);
+
+    (new CRM_EventsExtras_Hook_BuildForm_EventRegistrationThankYou())
+      ->handle(self::REGISTER_FORM_NAME, $form);
+
+    $this->assertSame($eventId, Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY));
+  }
+
+  private function fakeForm(?int $eventId, ?string $qfKey, bool $throwsOnGetEventID = FALSE): CRM_Event_Form_Registration_Register {
+    $form = new EventsExtras_TestDouble_RegistrationRegisterForm();
+    $form->_eventId = $eventId;
+    $form->throwOnGetEventID = $throwsOnGetEventID;
+    if ($qfKey !== NULL) {
+      $form->controller = (object) ['_key' => $qfKey];
+    }
+    return $form;
+  }
+
+}
+
+/**
+ * Thin subclass that skips the parent constructor and lets the test control
+ * what getEventID() returns or throws while still satisfying the
+ * CRM_Core_Form / CRM_Event_Form_Registration_Register type hints on the
+ * hook under test.
+ */
+class EventsExtras_TestDouble_RegistrationRegisterForm extends CRM_Event_Form_Registration_Register {
+
+  public bool $throwOnGetEventID = FALSE;
+
+  public function __construct() {
+  }
+
+  public function getEventID(): int {
+    if ($this->throwOnGetEventID) {
+      throw new RuntimeException('getEventID failure in test');
+    }
+    return (int) $this->_eventId;
+  }
+
+}

--- a/tests/phpunit/CRM/EventsExtras/Service/ThankYouPageRedirectTest.php
+++ b/tests/phpunit/CRM/EventsExtras/Service/ThankYouPageRedirectTest.php
@@ -1,0 +1,194 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+use CRM_EventsExtras_Service_ThankYouPageRedirect as Service;
+use CRM_EventsExtras_Test_Fabricator_Event as EventFabricator;
+
+require_once __DIR__ . '/../../../BaseHeadlessTest.php';
+
+/**
+ * @group headless
+ */
+class CRM_EventsExtras_Service_ThankYouPageRedirectTest extends BaseHeadlessTest {
+
+  private const QFKEY_A = 'test_qfkey_aaa';
+  private const QFKEY_B = 'test_qfkey_bbb';
+
+  public function setUp(): void {
+    $_GET = [];
+    $_POST = [];
+    $_REQUEST = [];
+    Civi::cache('session')->clear();
+  }
+
+  public function testStoreEventIdPersistsMapping(): void {
+    Service::storeEventId(self::QFKEY_A, 42);
+
+    $this->assertSame(42, Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY_A));
+  }
+
+  public function testStoreEventIdNoOpForEmptyQfKey(): void {
+    Service::storeEventId('', 42);
+
+    $this->assertNull(Civi::cache('session')->get(Service::CACHE_KEY_PREFIX));
+  }
+
+  public function testStoreEventIdNoOpForZeroEventId(): void {
+    Service::storeEventId(self::QFKEY_A, 0);
+
+    $this->assertNull(Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY_A));
+  }
+
+  public function testRedirectIfNeededNoOpWhenPathIsNotEventRegister(): void {
+    $event = EventFabricator::fabricate();
+    Service::storeEventId(self::QFKEY_A, (int) $event['id']);
+    $this->simulateThankYouRefresh(self::QFKEY_A);
+
+    $this->assertNoRedirect(function () {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'contribute', 'transact']));
+    });
+  }
+
+  public function testRedirectIfNeededNoOpWhenThankYouDisplayMissing(): void {
+    $event = EventFabricator::fabricate();
+    Service::storeEventId(self::QFKEY_A, (int) $event['id']);
+    $_REQUEST['qfKey'] = self::QFKEY_A;
+
+    $this->assertNoRedirect(function () {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+    });
+  }
+
+  public function testRedirectIfNeededNoOpWhenIdAlreadyInRequest(): void {
+    $event = EventFabricator::fabricate();
+    Service::storeEventId(self::QFKEY_A, (int) $event['id']);
+    $this->simulateThankYouRefresh(self::QFKEY_A);
+    $_REQUEST['id'] = (int) $event['id'];
+
+    $this->assertNoRedirect(function () {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+    });
+  }
+
+  public function testRedirectIfNeededNoOpWhenQfKeyMissing(): void {
+    $event = EventFabricator::fabricate();
+    Service::storeEventId(self::QFKEY_A, (int) $event['id']);
+    $_REQUEST['_qf_ThankYou_display'] = 1;
+
+    $this->assertNoRedirect(function () {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+    });
+  }
+
+  public function testRedirectIfNeededNoOpWhenWizardSessionStillHoldsId(): void {
+    $event = EventFabricator::fabricate();
+    $eventId = (int) $event['id'];
+
+    Service::storeEventId(self::QFKEY_A, $eventId);
+    $this->simulateThankYouRefresh(self::QFKEY_A);
+    Civi::cache('session')->set(
+      Service::WIZARD_SESSION_KEY_PREFIX . self::QFKEY_A,
+      ['id' => $eventId, 'qfKey' => self::QFKEY_A]
+    );
+
+    $this->assertNoRedirect(function () {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+    });
+  }
+
+  public function testRedirectIfNeededNoOpWhenNoMappingStored(): void {
+    $this->simulateThankYouRefresh(self::QFKEY_A);
+
+    $this->assertNoRedirect(function () {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+    });
+  }
+
+  public function testRedirectIfNeededClearsStaleMappingWhenEventIsDeleted(): void {
+    Service::storeEventId(self::QFKEY_A, 99999999);
+    $this->simulateThankYouRefresh(self::QFKEY_A);
+
+    $this->assertNoRedirect(function () {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+    });
+
+    $this->assertNull(Civi::cache('session')->get(Service::CACHE_KEY_PREFIX . self::QFKEY_A));
+  }
+
+  public function testRedirectIfNeededRedirectsToEventRegisterPage(): void {
+    $event = EventFabricator::fabricate();
+    $eventId = (int) $event['id'];
+
+    Service::storeEventId(self::QFKEY_A, $eventId);
+    $this->simulateThankYouRefresh(self::QFKEY_A);
+
+    try {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+      $this->fail('Expected CRM_Core_Exception_PrematureExitException was not thrown.');
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $url = $e->errorData['url'] ?? '';
+      $this->assertTrue(
+        strpos($url, 'civicrm/event/register') !== FALSE,
+        'Redirect URL should point to civicrm/event/register.'
+      );
+      $this->assertTrue(
+        strpos($url, 'id=' . $eventId) !== FALSE,
+        "Redirect URL should contain id={$eventId}."
+      );
+      $this->assertTrue(
+        strpos($url, 'reset=1') !== FALSE,
+        'Redirect URL should contain reset=1.'
+      );
+    }
+  }
+
+  public function testRedirectIfNeededResolvesPerQfKey(): void {
+    $eventA = EventFabricator::fabricate(['title' => 'Event A']);
+    $eventB = EventFabricator::fabricate(['title' => 'Event B']);
+    $idA = (int) $eventA['id'];
+    $idB = (int) $eventB['id'];
+
+    Service::storeEventId(self::QFKEY_A, $idA);
+    Service::storeEventId(self::QFKEY_B, $idB);
+
+    $this->simulateThankYouRefresh(self::QFKEY_B);
+
+    try {
+      Service::redirectIfNeeded($this->hookEvent(['civicrm', 'event', 'register']));
+      $this->fail('Expected CRM_Core_Exception_PrematureExitException was not thrown.');
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $url = $e->errorData['url'] ?? '';
+      $this->assertTrue(
+        strpos($url, 'id=' . $idB) !== FALSE,
+        "Redirect URL should resolve to event B (id={$idB})."
+      );
+      $this->assertTrue(
+        strpos($url, 'id=' . $idA) === FALSE,
+        "Redirect URL must not contain event A's id ({$idA})."
+      );
+    }
+  }
+
+  private function simulateThankYouRefresh(string $qfKey): void {
+    $_REQUEST['_qf_ThankYou_display'] = 1;
+    $_REQUEST['qfKey'] = $qfKey;
+    unset($_REQUEST['id']);
+  }
+
+  private function hookEvent(array $args): GenericHookEvent {
+    return GenericHookEvent::create(['args' => $args]);
+  }
+
+  private function assertNoRedirect(callable $fn): void {
+    try {
+      $fn();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $this->fail('Expected no redirect, but was redirected to ' . ($e->errorData['url'] ?? '?'));
+    }
+    $this->assertTrue(TRUE);
+  }
+
+}


### PR DESCRIPTION
## Overview

Refreshing the Thank You page of the event registration wizard produces an error: _"Could not find valid value for id"_ (rendered as _"Missing Event ID"_ on newer CiviCRM). This PR fixes the issue by redirecting the user to first page of event registration upon refresh of thank you page.

## Before
An error was shown to the user upon refreshing the thank you page
<img width="1440" height="122" alt="asesprt-821" src="https://github.com/user-attachments/assets/63fc6c55-d4f7-4378-9f74-50354f6543ac" />

## After
<img width="1777" height="857" alt="screen_recording_after" src="https://github.com/user-attachments/assets/8714c3df-9717-4b06-915c-df1fb6c6c4b2" />


## Technical Details

### Why it happens:

1. The whole wizard (Register → Confirm → Thank You) is served from a single route: `civicrm/event/register`.
2. The Thank You URL is `civicrm/event/register?_qf_ThankYou_display=1&qfKey=…` — it does **not** carry `id`; CiviCRM relies on its server-side wizard session cache to hold the event id.
3. On the first Thank You display, `CRM_Event_Form_Registration_ThankYou::buildQuickForm()` calls `$this->controller->reset()`, which flushes that session.
4. On refresh, `CRM_Event_StateMachine_Registration::__construct()` can't find `id` in the request or the session and throws.

### Fix

When the user lands on the first step of the wizard, record the `qfKey → eventId` mapping in a short-lived cache. Then, before CiviCRM instantiates the registration controller, detect a Thank You request whose session has been flushed and redirect the user back to the event's initial registration page (`civicrm/event/register?id=<eventId>&reset=1`) — instead of letting the state machine throw.

